### PR TITLE
Refactor the Service and Entity definations

### DIFF
--- a/entity/FactEntities.xml
+++ b/entity/FactEntities.xml
@@ -20,8 +20,9 @@ under the License.
 
 <entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/entity-definition-3.xsd">
     <entity entity-name="OrderItemFulfillmentFact" package="co.hotwax.bi.fact" group="analytical">
-        <field name="orderId" type="id" is-pk="true"/>
-        <field name="orderItemSeqId" type="id" is-pk="true"/>
+        <field name="orderItemFulfillmentFactId" type="id" is-pk="true"/>
+        <field name="orderId" type="id" />
+        <field name="orderItemSeqId" type="id" />
         <field name="externalId" type="text-short"/>
         <field name="orderName" type="text-short"/>
         <field name="orderTypeId" type="id"/>
@@ -74,10 +75,10 @@ under the License.
         <relationship type="one-nofk" related="co.hotwax.bi.dimension.ProductDimension">
             <key-map field-name="productId"/>
         </relationship>
-        <relationship type="one-nofk" related="co.hotwax.bi.dimension.DateDayDimension">
+        <relationship type="one-nofk" related="moqui.olap.DateDayDimension">
             <key-map field-name="itemCompletedDateDimId" related="dateValue"/>
         </relationship>
-        <relationship type="one-nofk" related="co.hotwax.bi.dimension.DateDayDimension">
+        <relationship type="one-nofk" related="moqui.olap.DateDayDimension">
             <key-map field-name="itemCancelledDateDimId" related="dateValue"/>
         </relationship>
     </entity>

--- a/service/co/hotwax/bi/DimensionServices.xml
+++ b/service/co/hotwax/bi/DimensionServices.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
     <!--    <service verb="load" type="script" noun="DateDimension" location="component://bi/src/loadDateDimension.groovy">-->
-    <service verb="load" noun="DateDayDimension">
+    <service verb="load" noun="DateDayDimension" transaction-timeout="300">
         <in-parameters>
             <parameter name="fromDate" type="Timestamp" format="yyyy-MM-dd" required="true">
                 <description>From date to generate the date dimension</description>


### PR DESCRIPTION
Doing some refactoring into the service and the entity definition
- Added the timeout to the `load#DateDayDimension` service because it is failing due to running time
- Changing the PK of the `OrderItemFulfillmentFact` entity, add a column `orderItemFulfillmentFactId` as PK which is the auto-generated sequence number