### PR TITLE
Feat: Read the content from SFTP file and load the data into Analytics Database Tables

### DIFF
--- a/data/SftpReadData.xml
+++ b/data/SftpReadData.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<entity-facade-xml type="demo">
+<entity-facade-xml type="ext">
     <moqui.service.message.SystemMessageType
             systemMessageTypeId="ReadOLAPData"
             description="Reads the CSV file from SFTP and stores the data in entity which is defined in CSV file"

--- a/data/SftpReadDemoData.xml
+++ b/data/SftpReadDemoData.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<entity-facade-xml type="demo">
+    <moqui.service.message.SystemMessageType
+            systemMessageTypeId="AnalyticsDataSync"
+            description="Upload the CSV file into Analytics Database"
+            consumeServiceName="co.hotwax.bi.SystemMessageServices.consume#AnalyticsDataSync"
+            receiveFilePattern=".*\.csv"
+            sendPath="${contentRoot}/DataWarehouse"
+            receiveMovePath="/home/${sftpUsername}/hotwax/DataWarehouse/archive"
+            receivePath="/home/${sftpUsername}/hotwax/DataWarehouse"
+            receiveResponseEnumId="MsgRrMove"
+    />
+
+    <moqui.service.job.ServiceJob
+            jobName="poll_SystemMessageFileSftp_AnalyticsDataSync"
+            description="poll for the Analytics Data files to SFTP location"
+            serviceName="co.hotwax.ofbiz.SystemMessageServices.poll#SystemMessageFileSftp"
+            cronExpression="0 0 0/12 * * ?" paused="Y"
+    >
+        <parameters parameterName="systemMessageTypeId" parameterValue="AnalyticsDataSync"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue="RemoteSftp"/>
+    </moqui.service.job.ServiceJob>
+
+</entity-facade-xml>

--- a/data/SftpReadDemoData.xml
+++ b/data/SftpReadDemoData.xml
@@ -2,9 +2,9 @@
 
 <entity-facade-xml type="demo">
     <moqui.service.message.SystemMessageType
-            systemMessageTypeId="AnalyticsDataSync"
-            description="Upload the CSV file into Analytics Database"
-            consumeServiceName="co.hotwax.bi.SystemMessageServices.consume#AnalyticsDataSync"
+            systemMessageTypeId="ReadOLAPData"
+            description="Reads the CSV file from SFTP and stores the data in entity which is defined in CSV file"
+            consumeServiceName="co.hotwax.bi.SystemMessageServices.consume#OlapDataSystemMessage"
             receiveFilePattern=".*\.csv"
             sendPath="${contentRoot}/DataWarehouse"
             receiveMovePath="/home/${sftpUsername}/hotwax/DataWarehouse/archive"
@@ -13,12 +13,12 @@
     />
 
     <moqui.service.job.ServiceJob
-            jobName="poll_SystemMessageFileSftp_AnalyticsDataSync"
-            description="poll for the Analytics Data files to SFTP location"
+            jobName="poll_SystemMessageFileSftp_ReadOLAPData"
+            description="Polls to see if there is any CSV file so that data can be stored in OLAP database"
             serviceName="co.hotwax.ofbiz.SystemMessageServices.poll#SystemMessageFileSftp"
             cronExpression="0 0 0/12 * * ?" paused="Y"
     >
-        <parameters parameterName="systemMessageTypeId" parameterValue="AnalyticsDataSync"/>
+        <parameters parameterName="systemMessageTypeId" parameterValue="ReadOLAPData"/>
         <parameters parameterName="systemMessageRemoteId" parameterValue="RemoteSftp"/>
     </moqui.service.job.ServiceJob>
 

--- a/service/co/hotwax/bi/SystemMessageServices.xml
+++ b/service/co/hotwax/bi/SystemMessageServices.xml
@@ -1,20 +1,17 @@
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
 
-    <service verb="consume" noun="AnalyticsDataSync">
+    <service verb="consume" noun="OlapDataSystemMessage">
         <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
         <actions>
-
             <entity-find-one entity-name="moqui.service.message.SystemMessage" value-field="systemMessage"/>
             <set field="fileText" from="ec.resource.getLocationReference(systemMessage.messageText).getText()"/>
-            <set field="edl" from="ec.entity.makeDataLoader()"/>
-
+            
             <script>
                 recordsLoaded = ec.entity.makeDataLoader().csvText(fileText).load()
             </script>
 
             <message>Loaded ${recordsLoaded} time summary records</message>
-
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/bi/SystemMessageServices.xml
+++ b/service/co/hotwax/bi/SystemMessageServices.xml
@@ -1,0 +1,20 @@
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
+
+    <service verb="consume" noun="AnalyticsDataSync">
+        <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
+        <actions>
+
+            <entity-find-one entity-name="moqui.service.message.SystemMessage" value-field="systemMessage"/>
+            <set field="fileText" from="ec.resource.getLocationReference(systemMessage.messageText).getText()"/>
+            <set field="edl" from="ec.entity.makeDataLoader()"/>
+
+            <script>
+                recordsLoaded = ec.entity.makeDataLoader().csvText(fileText).load()
+            </script>
+
+            <message>Loaded ${recordsLoaded} time summary records</message>
+
+        </actions>
+    </service>
+</services>


### PR DESCRIPTION
Issue: #4 

A new feature is added to the `oms-bi` component, to fetch the CSV files from the SFTP location and then Load the data into the **Analytics Database**

### Implementation
* Leverage the `SystemMessage` to read the files from the `SFTP` location and then move them to the archive folder at sftp
* Using the `EntityDataLoader` to load the contents of the CSV file into the Analytics DB
---

This Pull request includes the following changes
* Define a `consume#AnalyticsDataSync` service to consume the file that is read from the SFTP
* Write data to define the `SystemMessageType` & `ServiceJob` records