### PR TITLE
Add Two Additional fields to Fulfillment Fact Entity

### DIFF
--- a/entity/FactEntities.xml
+++ b/entity/FactEntities.xml
@@ -67,6 +67,8 @@ under the License.
         <field name="actualCost" type="currency-amount"/>
         <field name="pickerPartyId" type="id"/>
         <field name="itemDiscPerUnit" type="currency-amount"/>
+        <field name="fulfilledByUserLoginId" type="id"/>
+        <field name="itemTaxAmount" type="currency-amount"/>
         <relationship type="one-nofk" related="co.hotwax.bi.dimension.FacilityDimension">
             <key-map field-name="facilityId"/>
         </relationship>


### PR DESCRIPTION
Part of the Issue #12 

### Requirements
These two newly defined fields are required in the SM-specific report Sales by Item Level

- [Tax](https://git.hotwax.co/sm/reports/-/blob/develop/data/SQL/sales_by_item_level_nifi.sql?ref_type=heads#L22)
- [FulfilledBy](https://git.hotwax.co/sm/reports/-/blob/develop/data/SQL/sales_by_item_level_nifi.sql?ref_type=heads#L19)