### PR TITLE
Update OFC Fact Avro Schema

### DIFF
--- a/sql/avro_schema/OrderFacilityChangeFact.avsc
+++ b/sql/avro_schema/OrderFacilityChangeFact.avsc
@@ -5,7 +5,7 @@
   "name": "OrderFacilityChangeFact",
   "namespace": "co.hotwax.bi.fact",
   "fields": [
-    { "name": "ORDER_FACILITY_CHANGE_FACT_ID", "type": "string" },
+    { "name": "ORDER_FACILITY_CHANGE_FACT_ID", "type": "string", "aliases": ["PRIMARY_KEY"] },
     { "name": "ORDER_FACILITY_CHANGE_ID", "type": "string" },
     { "name": "ORDER_ID", "type": "string" },
     { "name": "ORDER_ITEM_SEQ_ID", "type": "string" },


### PR DESCRIPTION
Adding the primary key field alias because Nifi will add auto-generated value under the `PRIMARY_KEY` field in the data. Then while loading data this common field name will be renamed based on the corresponding Avro schema.